### PR TITLE
Fix sampling code example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ loss.backward() # Do this many times
 
 #### Sampling
 ```python
-from audio_diffusion_pytorch import DiffusionSampler, KerrasSchedule
+from audio_diffusion_pytorch import DiffusionSampler, KarrasSchedule
 
 sampler = DiffusionSampler(
     diffusion,


### PR DESCRIPTION
The **Sampling** example of the `README.md` imports a `KerrasSchedule` instead of `KarrasSchedule`.