### PR TITLE
Add Flash Attention

### DIFF
--- a/audio_diffusion_pytorch/model.py
+++ b/audio_diffusion_pytorch/model.py
@@ -131,7 +131,7 @@ class DiffusionAE1d(Model1d):
         length = closest_power_2(latent.shape[2] * self.encoder.downsample_factor)
         # Compute noise by inferring shape from latent length
         noise = torch.randn(b, self.in_channels, length, device=latent.device)
-        # Compute context form latent
+        # Compute context from latent
         default_kwargs = dict(channels_list=[latent])
         # Decode by sampling while conditioning on latent channels
         return super().sample(noise, **{**default_kwargs, **kwargs})
@@ -351,7 +351,7 @@ class AudioDiffusionAE(DiffusionAE1d):
                 in_channels=in_channels,
                 patch_size=16,
                 channels=16,
-                multipliers=[1, 2, 4, 4, 4, 4, 4],
+                multipliers=[2, 2, 4, 4, 4, 4, 4],
                 factors=[4, 4, 4, 2, 2, 2],
                 num_blocks=[2, 2, 2, 2, 2, 2],
                 out_channels=64,

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "einops>=0.4",
         "einops-exts>=0.0.3",
         "audio-encoders-pytorch",
+        "xformers @ git+https://github.com/facebookresearch/xformers.git@main#egg=xformers"
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
TransformerBlock now uses Flash Attention when `use_rel_pos` isn't needed. Note: I only tested this briefly with an untrained model for obvious crashes, and will continue with actual testing once I finish building a new training loop for my models. It works, but the results might not be correct.